### PR TITLE
Fixed numbering in 2.7.2 of crypto arch md version. 

### DIFF
--- a/architecture/Crypto Raamwerk.md
+++ b/architecture/Crypto Raamwerk.md
@@ -435,6 +435,7 @@ AVG technisch is er dan nog het ip-adres. Bij een upload is er een ip adres dat 
 
 4.  Authenticiteit van config files
 
+Details:
 
 1.  **Authenticiteit van de diagnosed keys:**
     Twee sporen:


### PR DESCRIPTION
Original document restarts count after introducing the 4 points of 2.7.2. Markdown doesn’t support it unless I insert a word. (Probably structure could be improved in original doc to avoid it). 