### PR TITLE
Static Swagger UI

### DIFF
--- a/architecture/api/index.html
+++ b/architecture/api/index.html
@@ -49,7 +49,7 @@
         ],
         layout: "StandaloneLayout",
         validatorUrl: "https://validator.swagger.io/validator",
-        url: "https://raw.githubusercontent.com/minvws/nl-covid19-notification-app-coordination/master/architecture/api/apispec.yaml",
+        url: "apispec.yaml",
       })
       
       

--- a/architecture/api/index.html
+++ b/architecture/api/index.html
@@ -1,0 +1,63 @@
+<!-- HTML for static distribution bundle build -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Swagger UI</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3.26.2/swagger-ui.css" integrity="sha256-/iY+q0zXad52K8yKYGzyqu9vRFIjcW096rdlzlOq/aU=" crossorigin="anonymous">
+    <style>
+      html
+      {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+      }
+
+      *,
+      *:before,
+      *:after
+      {
+        box-sizing: inherit;
+      }
+
+      body
+      {
+        margin:0;
+        background: #fafafa;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="swagger-ui"></div>
+
+    <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3.26.2/swagger-ui-bundle.js" integrity="sha256-ALUDV7h7/8gSJWkTdayl0FK/Z+9fObwmel1isjt9DW4=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3.26.2/swagger-ui-standalone-preset.js" integrity="sha256-UlScMe/sBo7ob5fk096A1bnWbkvZvWnr7KYYuiOXs8I=" crossorigin="anonymous"></script>
+    <script>
+    window.onload = function() {
+      
+      // Begin Swagger UI call region
+      const ui = SwaggerUIBundle({
+        "dom_id": "#swagger-ui",
+        deepLinking: true,
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        plugins: [
+          SwaggerUIBundle.plugins.DownloadUrl
+        ],
+        layout: "StandaloneLayout",
+        validatorUrl: "https://validator.swagger.io/validator",
+        url: "https://raw.githubusercontent.com/minvws/nl-covid19-notification-app-coordination/master/architecture/api/apispec.yaml",
+      })
+      
+      
+      // End Swagger UI call region
+
+
+      window.ui = ui
+    }
+  </script>
+  </body>
+</html>


### PR DESCRIPTION
> Maybe it's nicer if we put swagger-ui inside the repo and load it via github pages? I tried it but got a cors error on first attempt, but that was when the apispec file wasn't yet in the repo. (there's a howto here: https://peterevans.dev/posts/how-to-host-swagger-docs-with-github-pages/

_Originally posted by @ijansch in https://github.com/minvws/nl-covid19-notification-app-coordination/pull/40_

This can be done with a relative link, and therefore without <span title="Cross-Origin Resource Sharing">CORS</a> issues, see [my example](https://bwbroersma.github.io/nl-covid19-notification-app-coordination/architecture/api/index.html).

The only weird thing of the current Swagger UI link is the `petstore` part, but it's technically the same as this static file.